### PR TITLE
website: Remove broken nav link to undocumented avi_useraccount resource

### DIFF
--- a/website/avi.erb
+++ b/website/avi.erb
@@ -512,9 +512,6 @@
 		              <li<%= sidebar_current("docs-avi-serviceengine") %>>
               <a href="/docs/providers/avi/r/avi_serviceengine.html">ServiceEngine</a>
             </li>
-		              <li<%= sidebar_current("docs-avi-useraccount") %>>
-              <a href="/docs/providers/avi/r/avi_useraccount.html">UserAccount</a>
-            </li>
 		              <li<%= sidebar_current("docs-avi-fileservice") %>>
               <a href="/docs/providers/avi/r/avi_fileservice.html">FileService</a>
             </li>


### PR DESCRIPTION
Hello! The `avi_useraccount` resource seems to be completely undocumented, even though it's included on the index page and in several example configs. 

From the look of the rest of the docs, this is probably some kind of docs autogeneration malfunction; I'm not sure how this provider's special tooling works, so I can't advise on how to fix that. But in the meantime, this link to nowhere is causing nuisance failures in the Terraform website's build CI, so I'd be grateful if you could remove it until this resource's docs page starts existing. 

Thank you! 