### PR TITLE
AV-91605 Removed default value for internal field ocsp_error_status

### DIFF
--- a/avi/resource_avi_sslkeyandcertificate.go
+++ b/avi/resource_avi_sslkeyandcertificate.go
@@ -107,7 +107,7 @@ func ResourceSSLKeyAndCertificateSchema() map[string]*schema.Schema {
 		"ocsp_error_status": {
 			Type:     schema.TypeString,
 			Optional: true,
-			Default:  "OCSP_ERR_CERTSTATUS_DISABLED",
+			Computed: true,
 		},
 		"ocsp_response_info": {
 			Type:     schema.TypeSet,


### PR DESCRIPTION
In protobuf for internal field ocsp_error_status we are having default value 'OCSP_ERR_CERTSTATUS_DISABLED' because of this terraform trying to set the default value in payload for this internal field. We will fix this in auto generation code for next release. 